### PR TITLE
Add records and module origins support in Core  

### DIFF
--- a/src/lib/Lvm/Common/IdMap.hs
+++ b/src/lib/Lvm/Common/IdMap.hs
@@ -6,7 +6,7 @@
 --  $Id$
 
 module Lvm.Common.IdMap
-   ( IdMap, Id
+   ( IdMap(..), Id
      -- essential: used by "Asm" and "Lvm"
    , emptyMap, singleMap, elemMap, mapMap, insertMap, extendMap
    , insertMapWith, lookupMap, findMap, filterMap, listFromMap

--- a/src/lib/Lvm/Core/Expr.hs
+++ b/src/lib/Lvm/Core/Expr.hs
@@ -98,7 +98,7 @@ ppExpr p quantorNames expr = case expr of
       <>  text ": "
       <>  ppType 0 quantorNames t
       <+> text "->"
-      <+> ppExpr 0 quantorNames e
+      <$> indent 2 (ppExpr 0 quantorNames e)
   Forall quantor k e ->
     let quantorNames' = case quantor of
           Quantor idx (Just name) -> (idx, name) : quantorNames
@@ -109,7 +109,7 @@ ppExpr p quantorNames expr = case expr of
           <>  text ": "
           <>  pretty k
           <>  text "."
-          <+> ppExpr 0 quantorNames' e
+          <$> indent 2 (ppExpr 0 quantorNames' e)
   Ap e1 e2 -> prec 9 $ ppExpr 9 quantorNames e1 <+> ppExpr 10 quantorNames e2
   ApType e1 t ->
     prec 9

--- a/src/lib/Lvm/Core/Parsing/Lexer.hs
+++ b/src/lib/Lvm/Core/Parsing/Lexer.hs
@@ -60,8 +60,8 @@ lexer pos ('w' : 'i' : 't' : 'h' : cs) | nonId cs =
   (pos, LexWITH) : nextinc lexer pos 4 cs
 lexer pos ('c' : 'c' : 'a' : 'l' : 'l' : cs) | nonId cs =
   (pos, LexCCALL) : nextinc lexer pos 5 cs
-lexer pos ('p' : 'u' : 'b' : 'l' : 'i' : 'c' : cs) | nonId cs =
-  (pos, LexPUBLIC) : nextinc lexer pos 6 cs
+lexer pos ('e' : 'x' : 'p' : 'o' : 'r' : 't' : cs) | nonId cs =
+  (pos, LexEXPORT) : nextinc lexer pos 6 cs
 lexer pos ('e' : 'x' : 't' : 'e' : 'r' : 'n' : cs) | nonId cs =
   (pos, LexEXTERN) : nextinc lexer pos 6 cs
 lexer pos ('s' : 't' : 'a' : 't' : 'i' : 'c' : cs) | nonId cs =
@@ -70,8 +70,6 @@ lexer pos ('c' : 'u' : 's' : 't' : 'o' : 'm' : cs) | nonId cs =
   (pos, LexCUSTOM) : nextinc lexer pos 6 cs
 lexer pos ('n' : 'o' : 't' : 'h' : 'i' : 'n' : 'g' : cs) | nonId cs =
   (pos, LexNOTHING) : nextinc lexer pos 7 cs
-lexer pos ('p' : 'r' : 'i' : 'v' : 'a' : 't' : 'e' : cs) | nonId cs =
-  (pos, LexPRIVATE) : nextinc lexer pos 7 cs
 lexer pos ('d' : 'e' : 'f' : 'a' : 'u' : 'l' : 't' : cs) | nonId cs =
   (pos, LexDEFAULT) : nextinc lexer pos 7 cs
 lexer pos ('d' : 'y' : 'n' : 'a' : 'm' : 'i' : 'c' : cs) | nonId cs =
@@ -159,23 +157,23 @@ lexConOrQual pos cs =
   in  case rest of
         '.' : ds@(d : _)
           | isLower d || d == '_' -> lexWhile isLetter
-                                              (LexQualId ident)
+                                              (\n -> LexId $ ident ++ "." ++ n)
                                               pos
                                               (incpos pos' 1)
                                               ds
           | isUpper d -> lexWhile isLetter
-                                  (LexQualCon ident)
+                                  (\n -> LexCon $ ident ++ "." ++ n)
                                   pos
                                   (incpos pos' 1)
                                   ds
           | isSymbol d -> lexWhile isSymbol
-                                   (LexQualId ident)
+                                   (\n -> LexId $ ident ++ "." ++ n)
                                    pos
                                    (incpos pos' 1)
                                    ds
         '.' : '\'' : '\'' : ds -> case lexSpecialId pos (incpos pos 3) ds of
-          (pos1, LexCon s) : xs -> (pos1, LexQualCon ident s) : xs
-          (pos1, LexId s ) : xs -> (pos1, LexQualId ident s) : xs
+          (pos1, LexCon s) : xs -> (pos1, LexCon $ ident ++ "." ++ s) : xs
+          (pos1, LexId s ) : xs -> (pos1, LexId  $ ident ++ "." ++ s) : xs
           xs                    -> xs
         _ -> (pos, LexCon ident) : seq pos' (lexer pos' rest)
 

--- a/src/lib/Lvm/Core/Parsing/Lexer.hs
+++ b/src/lib/Lvm/Core/Parsing/Lexer.hs
@@ -62,6 +62,8 @@ lexer pos ('c' : 'c' : 'a' : 'l' : 'l' : cs) | nonId cs =
   (pos, LexCCALL) : nextinc lexer pos 5 cs
 lexer pos ('e' : 'x' : 'p' : 'o' : 'r' : 't' : cs) | nonId cs =
   (pos, LexEXPORT) : nextinc lexer pos 6 cs
+lexer pos ('f' : 'r' : 'o' : 'm' : cs) | nonId cs =
+  (pos, LexFROM) : nextinc lexer pos 4 cs
 lexer pos ('e' : 'x' : 't' : 'e' : 'r' : 'n' : cs) | nonId cs =
   (pos, LexEXTERN) : nextinc lexer pos 6 cs
 lexer pos ('s' : 't' : 'a' : 't' : 'i' : 'c' : cs) | nonId cs =

--- a/src/lib/Lvm/Core/Parsing/Parser.hs
+++ b/src/lib/Lvm/Core/Parsing/Parser.hs
@@ -1,6 +1,6 @@
 --------------------------------------------------------------------------------
--- Copyright 2001-2012, Daan Leijen, Bastiaan Heeren, Jurriaan Hage. This file 
--- is distributed under the terms of the BSD3 License. For more information, 
+-- Copyright 2001-2012, Daan Leijen, Bastiaan Heeren, Jurriaan Hage. This file
+-- is distributed under the terms of the BSD3 License. For more information,
 -- see the file "LICENSE.txt", which is included in the distribution.
 --------------------------------------------------------------------------------
 --  $Id$
@@ -177,7 +177,7 @@ pabstractCon = do
   t <- ptype
   let access | isImported acc = acc
              | otherwise      = Imported False mid impid DeclKindCon 0 0
-  return (DeclCon x access t custom)
+  return (DeclCon x access t [] custom)
 
 isImported :: Access -> Bool
 isImported Imported{} = True
@@ -298,7 +298,7 @@ pconDecl = do
   (access, custom) <- pAttributes public
   lexeme LexCOLCOL
   t <- ptype
-  return $ DeclCon x access t custom
+  return $ DeclCon x access t [] custom
 
 -- constructor info: (@tag, arity)
 pConInfo :: TokenParser (Tag, Arity)
@@ -379,7 +379,7 @@ pdata = do
       lexeme LexASG
       let t1 = foldl TAp (TCon $ TConDataType x) (map TVar args)
       cons <- sepBy1 (pconstructor t1) (lexeme LexBAR)
-      let con (cid, t2) = DeclCon cid public t2 [CustomLink x customData]
+      let con (cid, t2) = DeclCon cid public t2 [] [CustomLink x customData]
       return (datadecl : map con cons)
     <|> {- empty data types -}
         return [datadecl]
@@ -912,7 +912,7 @@ qualifiedVar = do
   return (idFromString m, idFromString name)
 
 bindid :: TokenParser Id
-bindid = varid {- 
+bindid = varid {-
   = do{ x <- varid
       ; do{ lexeme LexEXCL
           ; return x {- (setSortId SortStrict id) -}

--- a/src/lib/Lvm/Core/Parsing/Token.hs
+++ b/src/lib/Lvm/Core/Parsing/Token.hs
@@ -31,10 +31,8 @@ data Lexeme     = LexUnknown Char
                 | LexFloat Double
                 | LexId String
                 | LexTypeVar Int
-                | LexQualId String String
                 | LexOp String
                 | LexCon String
-                | LexQualCon String String
                 | LexConOp String
 
                 | LexCOMMA      -- ,
@@ -82,8 +80,7 @@ data Lexeme     = LexUnknown Char
                 | LexLETSTRICT
                 | LexWITH
 
-                | LexPRIVATE
-                | LexPUBLIC
+                | LexEXPORT
                 | LexDEFAULT
                 | LexCON
 

--- a/src/lib/Lvm/Core/Parsing/Token.hs
+++ b/src/lib/Lvm/Core/Parsing/Token.hs
@@ -81,6 +81,7 @@ data Lexeme     = LexUnknown Char
                 | LexWITH
 
                 | LexEXPORT
+                | LexFROM
                 | LexDEFAULT
                 | LexCON
 

--- a/src/lib/Lvm/Import.hs
+++ b/src/lib/Lvm/Import.hs
@@ -64,7 +64,11 @@ lvmImport findModule m = do
 lvmImportDecls :: Monad m => (Id -> m (Module v)) -> [Id] -> m [Decl v]
 lvmImportDecls findModule names = do
   modules <- mapM findModule $ nub names
-  return $ modules >>= (filter (accessPublic . declAccess) . moduleDecls)
+  return $ modules >>= (filter 
+    (\decl -> accessPublic (declAccess decl) 
+      && not (declKindFromDecl decl == DeclKindCon
+      && "Dict$" `isPrefixOf` stringFromId (declName decl)))
+      . moduleDecls)
 
 -- Constructs a map, converting unqualified names to fully qualified names,
 -- for both the value namespace (first field) and the types name space (second field)

--- a/src/lib/Lvm/Import.hs
+++ b/src/lib/Lvm/Import.hs
@@ -73,11 +73,7 @@ lvmImportRenameMap = foldl' (flip insert) (emptyMap, emptyMap)
   where
     insert decl (valuesMap, typesMap) = case declAccess decl of
       Export alias
-        | isDeclInfix decl ->
-          let
-            qualified = stringFromId (fromJust $ declModule decl) ++ "." ++ stringFromId alias
-            valuesMap' = insertMap alias (idFromString qualified) valuesMap
-          in (valuesMap, typesMap)
+        | isDeclInfix decl -> (valuesMap, typesMap)
         | declaresValue decl ->
           let valuesMap' = insertMap alias name valuesMap
           in valuesMap' `seq` (valuesMap', typesMap)
@@ -90,8 +86,7 @@ lvmImportRenameMap = foldl' (flip insert) (emptyMap, emptyMap)
 -- Makes variable names quantified.
 lvmImportQualifyModule :: (IdMap Id, IdMap Id) -> CoreModule -> Bool -> CoreModule
 lvmImportQualifyModule (valuesMap, typesMap) (Module modName modMajor modMinor modImports modDecls) shouldRenameOwn
-  ={- traceShow (pretty (sort $ listFromMap valuesMap, sort $ listFromMap typesMap)) $ -}
-    Module modName modMajor modMinor modImports $ map travDecl modDecls
+  = Module modName modMajor modMinor modImports $ map travDecl modDecls
   where
     -- TODO: Cleanup and refactor how infix declarations are treated
     (valueDecls', typeDecls) = partition declaresValue modDecls


### PR DESCRIPTION
This adds support in Core for specifying a record's fields and for specifying where a function was originally defined.