### PR TITLE
fix gcc-10 build (-fno-common)

### DIFF
--- a/src/runtime/common/bytes.h
+++ b/src/runtime/common/bytes.h
@@ -20,6 +20,6 @@
 
 value alloc_bytes( asize_t size );
 value bytes_of_string( value s );
-struct custom_operations bytes_ops;
+extern struct custom_operations bytes_ops;
 
 #endif /* _bytes_ */

--- a/src/runtime/core/failexn.h
+++ b/src/runtime/core/failexn.h
@@ -78,7 +78,7 @@ struct exception_frame {
                    } \
                  }
 
-struct exception_frame* global_exn_frame;
+extern struct exception_frame* global_exn_frame;
 
 
 #endif /* _failexn_h */


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build of lvmrun fails as:

    ...
    gcc -o lvmrun ... -lm -ldl
    ld: core/module.o:(.bss+0x0): multiple definition of `bytes_ops'; core/loader.o:(.bss+0x0): first defined here
    ld: core/fail.o:(.bss+0x0): multiple definition of `global_exn_frame'; core/evaluator.o:(.bss+0x10): first defined here
    ld: core/signals.o:(.bss+0x8): multiple definition of `global_exn_frame'; core/evaluator.o:(.bss+0x10): first defined here
    ld: heap/bytes.o:(.data.rel.local+0x0): multiple definition of `bytes_ops'; core/loader.o:(.bss+0x0): first defined here

The change drops excessive variable definitions from headers.